### PR TITLE
Problem matcher improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ for common linters (see [list](#available-problem-matchers) below).
 * ansible-lint (requires `--parseable` flag or `parseable: true` in config)
 * black
 * eslint
-* flake8
 * isort
 * markdownlint
 * mypy
-* pycodestyle
+* pycodestyle-error
+* pycodestyle-warning
 * pydocstyle
 * pylint-error
 * pylint-warning

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ for common linters (see [list](#available-problem-matchers) below).
 * isort
 * markdownlint
 * mypy
-* pycodestyle-error
-* pycodestyle-warning
+* pycodestyle-error (also works for linters that use the same output format, like flake8)
+* pycodestyle-warning (also works for linters that use the same output format, like flake8)
 * pydocstyle
 * pylint-error
 * pylint-warning

--- a/matchers/actionlint.json
+++ b/matchers/actionlint.json
@@ -5,11 +5,12 @@
             "severity": "error",
             "pattern": [
                 {
-                    "regexp": "^([^:]+):(\\d+):(\\d+): (?!\\[[a-z]+\\] )(.*)$",
+                    "regexp": "^(.+?):(\\d+):(\\d+): (.+) \\[(.+)\\]$",
                     "file": 1,
                     "line": 2,
                     "column": 3,
-                    "message": 4
+                    "message": 4,
+                    "code": 5
                 }
             ]
         }

--- a/matchers/ansible-lint.json
+++ b/matchers/ansible-lint.json
@@ -5,10 +5,12 @@
             "severity": "error",
             "pattern": [
                 {
-                    "regexp": "^([^:]+):(\\d+): (.*)$",
+                    "regexp": "^(.+?):(\\d+):(?:(\\d+):)? (?![A-Z]\\d+: )(\\S+): (.+)$",
                     "file": 1,
                     "line": 2,
-                    "message": 3
+                    "column": 3,
+                    "code": 4,
+                    "message": 5
                 }
             ]
         }

--- a/matchers/black.json
+++ b/matchers/black.json
@@ -3,14 +3,11 @@
         {
             "owner": "black",
             "severity": "warning",
-            "column": 1,
-            "line": 1,
-            "code": "W",
             "pattern": [
                 {
-                    "regexp": "^(would reformat) (.*)$",
-                    "file": 2,
-                    "message": 1
+                    "regexp": "^(would reformat) (.+)$",
+                    "message": 1,
+                    "file": 2
                 }
             ]
         }

--- a/matchers/eslint.json
+++ b/matchers/eslint.json
@@ -9,11 +9,12 @@
                     "file": 1
                 },
                 {
-                    "regexp": "^  (\\d+):(\\d+)  (?=[a-z]+)(error|warning)?[a-z]*  (.*)$",
+                    "regexp": "^ +(\\d+):(\\d+) +(?:(error|warning)|[a-z]+) +(.+?)(?: {2,}(\\S+))?$",
                     "line": 1,
                     "column": 2,
                     "severity": 3,
                     "message": 4,
+                    "code": 5,
                     "loop": true
                 }
             ]

--- a/matchers/isort.json
+++ b/matchers/isort.json
@@ -4,9 +4,9 @@
             "owner": "isort",
             "pattern": [
                 {
-                    "regexp": "^(\\S*): (\\S*) (.*)$",
-                    "file": 2,
+                    "regexp": "^([A-Z]+): (.+?) (.+)$",
                     "severity": 1,
+                    "file": 2,
                     "message": 3
                 }
             ]

--- a/matchers/mypy.json
+++ b/matchers/mypy.json
@@ -2,13 +2,13 @@
     "problemMatcher": [
         {
             "owner": "mypy",
-            "code": "E",
+            "severity": "notice",
             "pattern": [
                 {
-                    "regexp": "^(\\S*):(\\d+):(\\d+): ([a-z]+): (.*)$",
+                    "regexp": "^(.+?):(\\d+):(?:(\\d+):)? (?:(error|warning)|[a-z]+): (.+)$",
                     "file": 1,
-                    "column": 3,
                     "line": 2,
+                    "column": 3,
                     "severity": 4,
                     "message": 5
                 }

--- a/matchers/pycodestyle-error.json
+++ b/matchers/pycodestyle-error.json
@@ -1,11 +1,11 @@
 {
     "problemMatcher": [
         {
-            "owner": "flake8",
-            "severity": "warning",
+            "owner": "pycodestyle-error",
+            "severity": "error",
             "pattern": [
                 {
-                    "regexp": "(\\S+):(\\d+):(\\d+): ([A-Z]\\d+) (.*)",
+                    "regexp": "^(.+?):(\\d+):(\\d+): ([A-VX-Z]\\d+) (.+)$",
                     "file": 1,
                     "line": 2,
                     "column": 3,

--- a/matchers/pycodestyle-warning.json
+++ b/matchers/pycodestyle-warning.json
@@ -1,11 +1,11 @@
 {
     "problemMatcher": [
         {
-            "owner": "pycodestyle",
+            "owner": "pycodestyle-warning",
             "severity": "warning",
             "pattern": [
                 {
-                    "regexp": "^(\\S*):(\\d+):(\\d+): ([A-Z]\\d+) (.*)$",
+                    "regexp": "^(.+?):(\\d+):(\\d+): (W\\d+) (.+)$",
                     "file": 1,
                     "line": 2,
                     "column": 3,

--- a/matchers/pydocstyle.json
+++ b/matchers/pydocstyle.json
@@ -3,17 +3,16 @@
         {
             "owner": "pydocstyle",
             "severity": "warning",
-            "column": 1,
             "pattern": [
                 {
-                    "regexp": "^(\\S*):(\\d*) .*",
+                    "regexp": "^(.+?):(\\d+) in .+$",
                     "file": 1,
                     "line": 2
                 },
                 {
-                    "regexp": "\\s*(D\\d*): (.*)$",
-                    "message": 2,
-                    "code": 1
+                    "regexp": "\\s*(D\\d+): (.+)$",
+                    "code": 1,
+                    "message": 2
                 }
             ]
         }

--- a/matchers/pylint-error.json
+++ b/matchers/pylint-error.json
@@ -5,7 +5,7 @@
             "severity": "error",
             "pattern": [
                 {
-                    "regexp": "^([^:]+):(\\d+):(\\d+): (E\\d+): (.*)$",
+                    "regexp": "^(.+?):(\\d+):(\\d+): (E\\d+): (.+)$",
                     "file": 1,
                     "line": 2,
                     "column": 3,

--- a/matchers/pylint-warning.json
+++ b/matchers/pylint-warning.json
@@ -5,7 +5,7 @@
             "severity": "warning",
             "pattern": [
                 {
-                    "regexp": "^([^:]+):(\\d+):(\\d+): ([A-DF-Z]\\d+): (.*)$",
+                    "regexp": "^(.+?):(\\d+):(\\d+): ([A-DF-Z]\\d+): (.+)$",
                     "file": 1,
                     "line": 2,
                     "column": 3,

--- a/matchers/shellcheck.json
+++ b/matchers/shellcheck.json
@@ -5,7 +5,7 @@
             "severity": "notice",
             "pattern": [
                 {
-                    "regexp": "^.*In ([^\\s]+) line (\\d+):.*$",
+                    "regexp": "^.*In (.+?) line (\\d+):.*$",
                     "file": 1,
                     "line": 2
                 },
@@ -13,7 +13,7 @@
                     "regexp": "^.+$"
                 },
                 {
-                    "regexp": "^.*(SC\\d+) \\((?=[a-z]+)(error|warning)?[a-z]*\\): ([^\\033]+).*$",
+                    "regexp": "^.*(SC\\d+) \\((?:(error|warning)|[a-z]+)\\): ([^\\033]+).*$",
                     "code": 1,
                     "severity": 2,
                     "message": 3,

--- a/matchers/vulture.json
+++ b/matchers/vulture.json
@@ -2,9 +2,10 @@
     "problemMatcher": [
         {
             "owner": "vulture",
+            "severity": "error",
             "pattern": [
                 {
-                    "regexp": "^([^:]+):(\\d+): ([^(]+ \\(\\d+% confidence\\))$",
+                    "regexp": "^(.+?):(\\d+): (.+ \\(\\d+% confidence\\))$",
                     "file": 1,
                     "line": 2,
                     "message": 3

--- a/matchers/yamllint.json
+++ b/matchers/yamllint.json
@@ -5,12 +5,13 @@
             "severity": "notice",
             "pattern": [
                 {
-                    "regexp": "^([^:]+):(\\d+):(\\d+): \\[(?=[a-z]+)(error|warning)?[a-z]*\\] (.*)$",
+                    "regexp": "^(.+?):(\\d+):(\\d+): \\[(?:(error|warning)|[a-z]+)\\] (.+) \\((.+)\\)$",
                     "file": 1,
                     "line": 2,
                     "column": 3,
                     "severity": 4,
-                    "message": 5
+                    "message": 5,
+                    "code": 6
                 }
             ]
         }


### PR DESCRIPTION
* Allow any character for filenames (by using a lazy one-or-more wildcard match)
* Use one-or-more (`+`) for most cases where text is required
* Order attributes to the same order they are captured
* Remove defaults that aren't `"severity"`
* Update regex so that none are conflicting
* Simplifications where possible
* Make some regex a more accurate match